### PR TITLE
Updated OpenAPI3.yaml using version 1.7.4 Enums from Fireblocks

### DIFF
--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -26802,6 +26802,9 @@ namespace Trakx.Fireblocks.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"SEEDCX")]
         SEEDCX = 25,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"GATEIO")]
+        GATEIO = 26,
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.2.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]

--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -26748,80 +26748,59 @@ namespace Trakx.Fireblocks.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"BITTREX")]
         BITTREX = 7,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"BLINC")]
-        BLINC = 8,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"BYBIT")]
-        BYBIT = 9,
-
         [System.Runtime.Serialization.EnumMember(Value = @"CIRCLE")]
-        CIRCLE = 10,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"COINBASEEXCHANGE")]
-        COINBASEEXCHANGE = 11,
+        CIRCLE = 8,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINBASEPRO")]
-        COINBASEPRO = 12,
+        COINBASEPRO = 9,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINMETRO")]
-        COINMETRO = 13,
+        COINMETRO = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINSPRO")]
-        COINSPRO = 14,
+        COINSPRO = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"CRYPTOCOM")]
-        CRYPTOCOM = 15,
+        CRYPTOCOM = 12,
 
         [System.Runtime.Serialization.EnumMember(Value = @"DERIBIT")]
-        DERIBIT = 16,
+        DERIBIT = 13,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"FTX")]
+        FTX = 14,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"FIXUS")]
+        FIXUS = 15,
 
         [System.Runtime.Serialization.EnumMember(Value = @"GEMINI")]
-        GEMINI = 17,
+        GEMINI = 16,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HITBTC")]
-        HITBTC = 18,
+        HITBTC = 17,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HUOBI")]
-        HUOBI = 19,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"INDEPENDENTRESERVE")]
-        INDEPENDENTRESERVE = 20,
+        HUOBI = 18,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KORBIT")]
-        KORBIT = 21,
+        KORBIT = 19,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KRAKEN")]
-        KRAKEN = 22,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"KRAKENINTL")]
-        KRAKENINTL = 23,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"KUCOIN")]
-        KUCOIN = 24,
+        KRAKEN = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"LIQUID")]
-        LIQUID = 25,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"OKCOIN")]
-        OKCOIN = 26,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"OKEX")]
-        OKEX = 27,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"PAXOS")]
-        PAXOS = 28,
+        LIQUID = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"POLONIEX")]
-        POLONIEX = 29,
+        POLONIEX = 22,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"External")]
-        External = 30,
+        [System.Runtime.Serialization.EnumMember(Value = @"OKCOIN")]
+        OKCOIN = 23,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"Internal")]
-        Internal = 31,
+        [System.Runtime.Serialization.EnumMember(Value = @"OKEX")]
+        OKEX = 24,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"GATEIO")]
-        GATEIO = 32,
+        [System.Runtime.Serialization.EnumMember(Value = @"SEEDCX")]
+        SEEDCX = 25,
 
     }
 

--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -26748,59 +26748,80 @@ namespace Trakx.Fireblocks.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"BITTREX")]
         BITTREX = 7,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"BLINC")]
+        BLINC = 8,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"BYBIT")]
+        BYBIT = 9,
+
         [System.Runtime.Serialization.EnumMember(Value = @"CIRCLE")]
-        CIRCLE = 8,
+        CIRCLE = 10,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"COINBASEEXCHANGE")]
+        COINBASEEXCHANGE = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINBASEPRO")]
-        COINBASEPRO = 9,
+        COINBASEPRO = 12,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINMETRO")]
-        COINMETRO = 10,
+        COINMETRO = 13,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINSPRO")]
-        COINSPRO = 11,
+        COINSPRO = 14,
 
         [System.Runtime.Serialization.EnumMember(Value = @"CRYPTOCOM")]
-        CRYPTOCOM = 12,
+        CRYPTOCOM = 15,
 
         [System.Runtime.Serialization.EnumMember(Value = @"DERIBIT")]
-        DERIBIT = 13,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"FTX")]
-        FTX = 14,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"FIXUS")]
-        FIXUS = 15,
+        DERIBIT = 16,
 
         [System.Runtime.Serialization.EnumMember(Value = @"GEMINI")]
-        GEMINI = 16,
+        GEMINI = 17,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HITBTC")]
-        HITBTC = 17,
+        HITBTC = 18,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HUOBI")]
-        HUOBI = 18,
+        HUOBI = 19,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"INDEPENDENTRESERVE")]
+        INDEPENDENTRESERVE = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KORBIT")]
-        KORBIT = 19,
+        KORBIT = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KRAKEN")]
-        KRAKEN = 20,
+        KRAKEN = 22,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"KRAKENINTL")]
+        KRAKENINTL = 23,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"KUCOIN")]
+        KUCOIN = 24,
 
         [System.Runtime.Serialization.EnumMember(Value = @"LIQUID")]
-        LIQUID = 21,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"POLONIEX")]
-        POLONIEX = 22,
+        LIQUID = 25,
 
         [System.Runtime.Serialization.EnumMember(Value = @"OKCOIN")]
-        OKCOIN = 23,
+        OKCOIN = 26,
 
         [System.Runtime.Serialization.EnumMember(Value = @"OKEX")]
-        OKEX = 24,
+        OKEX = 27,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"SEEDCX")]
-        SEEDCX = 25,
+        [System.Runtime.Serialization.EnumMember(Value = @"PAXOS")]
+        PAXOS = 28,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"POLONIEX")]
+        POLONIEX = 29,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"External")]
+        External = 30,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Internal")]
+        Internal = 31,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"GATEIO")]
+        GATEIO = 32,
 
     }
 

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -8925,6 +8925,7 @@ components:
         - OKCOIN
         - OKEX
         - SEEDCX
+        - GATEIO
     ExchangeAsset:
       type: object
       properties:

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -8907,24 +8907,31 @@ components:
         - BITSO
         - BITSTAMP
         - BITTREX
+        - BLINC
+        - BYBIT
         - CIRCLE
+        - COINBASEEXCHANGE
         - COINBASEPRO
         - COINMETRO
         - COINSPRO
         - CRYPTOCOM
         - DERIBIT
-        - FTX
-        - FIXUS
         - GEMINI
         - HITBTC
         - HUOBI
+        - INDEPENDENTRESERVE
         - KORBIT
         - KRAKEN
+        - KRAKENINTL
+        - KUCOIN
         - LIQUID
-        - POLONIEX
         - OKCOIN
         - OKEX
-        - SEEDCX
+        - PAXOS
+        - POLONIEX
+        - External
+        - Internal
+        - GATEIO
     ExchangeAsset:
       type: object
       properties:

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -8907,31 +8907,24 @@ components:
         - BITSO
         - BITSTAMP
         - BITTREX
-        - BLINC
-        - BYBIT
         - CIRCLE
-        - COINBASEEXCHANGE
         - COINBASEPRO
         - COINMETRO
         - COINSPRO
         - CRYPTOCOM
         - DERIBIT
+        - FTX
+        - FIXUS
         - GEMINI
         - HITBTC
         - HUOBI
-        - INDEPENDENTRESERVE
         - KORBIT
         - KRAKEN
-        - KRAKENINTL
-        - KUCOIN
         - LIQUID
+        - POLONIEX
         - OKCOIN
         - OKEX
-        - PAXOS
-        - POLONIEX
-        - External
-        - Internal
-        - GATEIO
+        - SEEDCX
     ExchangeAsset:
       type: object
       properties:

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleGetAllExchangesResponse.json
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleGetAllExchangesResponse.json
@@ -1,8 +1,8 @@
 [
   {
     "id": "18507832-08ed-81af-912f-c1064b7af31b",
-    "name": "FTX",
-    "type": "FTX",
+    "name": "GATEIO",
+    "type": "GATEIO",
     "assets": [],
     "isSubaccount": false,
     "status": "APPROVED"


### PR DESCRIPTION
Interestingly GATEIO is not in the latest version of OpenAPI3.yam from Fireblocks
https://github.com/fireblocks/fireblocks-openapi-spec/blob/main/open_api_spec.yml