### PR TITLE
Updated ExchangeType Enum based on the latest version of Fireblocks API

### DIFF
--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -26748,62 +26748,68 @@ namespace Trakx.Fireblocks.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"BITTREX")]
         BITTREX = 7,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"CIRCLE")]
-        CIRCLE = 8,
+        [System.Runtime.Serialization.EnumMember(Value = @"BYBIT")]
+        BYBIT = 8,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CIRCLEO")]
+        CIRCLEO = 9,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"COINBASEEXCHANGE")]
+        COINBASEEXCHANGE = 10,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINBASEPRO")]
-        COINBASEPRO = 9,
+        COINBASEPRO = 11,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINMETRO")]
-        COINMETRO = 10,
+        COINMETRO = 12,
 
         [System.Runtime.Serialization.EnumMember(Value = @"COINSPRO")]
-        COINSPRO = 11,
+        COINSPRO = 13,
 
         [System.Runtime.Serialization.EnumMember(Value = @"CRYPTOCOM")]
-        CRYPTOCOM = 12,
+        CRYPTOCOM = 14,
 
         [System.Runtime.Serialization.EnumMember(Value = @"DERIBIT")]
-        DERIBIT = 13,
+        DERIBIT = 15,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"FTX")]
-        FTX = 14,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"FIXUS")]
-        FIXUS = 15,
+        [System.Runtime.Serialization.EnumMember(Value = @"GATE")]
+        GATE = 16,
 
         [System.Runtime.Serialization.EnumMember(Value = @"GEMINI")]
-        GEMINI = 16,
+        GEMINI = 17,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HITBTC")]
-        HITBTC = 17,
+        HITBTC = 18,
 
         [System.Runtime.Serialization.EnumMember(Value = @"HUOBI")]
-        HUOBI = 18,
+        HUOBI = 19,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"IR")]
+        IR = 20,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KORBIT")]
-        KORBIT = 19,
+        KORBIT = 21,
 
         [System.Runtime.Serialization.EnumMember(Value = @"KRAKEN")]
-        KRAKEN = 20,
+        KRAKEN = 22,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"KRAKENINTL")]
+        KRAKENINTL = 23,
 
         [System.Runtime.Serialization.EnumMember(Value = @"LIQUID")]
-        LIQUID = 21,
+        LIQUID = 24,
 
         [System.Runtime.Serialization.EnumMember(Value = @"POLONIEX")]
-        POLONIEX = 22,
+        POLONIEX = 25,
 
         [System.Runtime.Serialization.EnumMember(Value = @"OKCOIN")]
-        OKCOIN = 23,
+        OKCOIN = 26,
 
         [System.Runtime.Serialization.EnumMember(Value = @"OKEX")]
-        OKEX = 24,
+        OKEX = 27,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SEEDCX")]
-        SEEDCX = 25,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"GATEIO")]
-        GATEIO = 26,
+        SEEDCX = 28,
 
     }
 

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -8907,25 +8907,27 @@ components:
         - BITSO
         - BITSTAMP
         - BITTREX
-        - CIRCLE
+        - BYBIT
+        - CIRCLEO
+        - COINBASEEXCHANGE
         - COINBASEPRO
         - COINMETRO
         - COINSPRO
         - CRYPTOCOM
         - DERIBIT
-        - FTX
-        - FIXUS
+        - GATE
         - GEMINI
         - HITBTC
         - HUOBI
+        - IR
         - KORBIT
         - KRAKEN
+        - KRAKENINTL
         - LIQUID
         - POLONIEX
         - OKCOIN
         - OKEX
         - SEEDCX
-        - GATEIO
     ExchangeAsset:
       type: object
       properties:

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleGetAllExchangesResponse.json
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleGetAllExchangesResponse.json
@@ -1,8 +1,8 @@
 [
   {
     "id": "18507832-08ed-81af-912f-c1064b7af31b",
-    "name": "GATEIO",
-    "type": "GATEIO",
+    "name": "GATE",
+    "type": "GATE",
     "assets": [],
     "isSubaccount": false,
     "status": "APPROVED"


### PR DESCRIPTION
Updated enums from:
https://developers.fireblocks.com/reference/exchange-objects#exchangetype

otherwise api client is parsing wrong:
![image](https://github.com/trakx/fireblocks-api-client/assets/13721403/0173e8f6-3f09-4d43-adfa-3fdb002f0bed)

IMPORTANT: GitHub Fireblocks Docs are not maintained anymore apparently, need to use API Docs directly