### PR TITLE
Remove enum of Type field of AssetTypeResponse

### DIFF
--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -27914,8 +27914,7 @@ namespace Trakx.Fireblocks.ApiClient
 
         [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public AssetTypeResponseType Type { get; set; }
+        public string Type { get; set; }
 
         [Newtonsoft.Json.JsonProperty("contractAddress", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ContractAddress { get; init; }
@@ -35452,45 +35451,6 @@ namespace Trakx.Fireblocks.ApiClient
 
         [System.Runtime.Serialization.EnumMember(Value = @"FIAT_ACCOUNT")]
         FIAT_ACCOUNT = 0,
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.2.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public enum AssetTypeResponseType
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"ALGO_ASSET")]
-        ALGO_ASSET = 0,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"BASE_ASSET")]
-        BASE_ASSET = 1,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"BEP20")]
-        BEP20 = 2,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"COMPOUND")]
-        COMPOUND = 3,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"ERC20")]
-        ERC20 = 4,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"FIAT")]
-        FIAT = 5,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"SOL_ASSET")]
-        SOL_ASSET = 6,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"TRON_TRC20")]
-        TRON_TRC20 = 7,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"XLM_ASSET")]
-        XLM_ASSET = 8,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"XDB_ASSET")]
-        XDB_ASSET = 9,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"NEAR_ASSET")]
-        NEAR_ASSET = 10,
 
     }
 

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -9565,18 +9565,6 @@ components:
           type: string
         type:
           type: string
-          enum:
-            - ALGO_ASSET
-            - BASE_ASSET
-            - BEP20
-            - COMPOUND
-            - ERC20
-            - FIAT
-            - SOL_ASSET
-            - TRON_TRC20
-            - XLM_ASSET
-            - XDB_ASSET
-            - NEAR_ASSET
         contractAddress:
           type: string
         nativeAsset:


### PR DESCRIPTION
There is an issue with the updated enum values in Fireblocks API Client.
For example, the previous `AssetTypeResponseType` doesn't have the `XRP_ASSET` value, which it is not listed in their Open API spec.
So, the solution is to stop using it as enum, but only string. If we need to validate something, we should use local constants for that.

Open API spec:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/e050746c-36dd-46e7-a478-3f8e3bd158b4">

Error log with invalid value:
<img width="1563" alt="image" src="https://github.com/user-attachments/assets/94582ae9-4ffe-43d6-8d23-f7e4291dbdda">
