### PR TITLE
Retrieve RSA public key for exchange credentials encryption

### DIFF
--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiClients.cs
@@ -3860,6 +3860,87 @@ namespace Trakx.Fireblocks.ApiClient
             }
         }
 
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get exchange credentials public key
+        /// </summary>
+        /// <remarks>
+        /// Returns the public key used to encrypt exchange account credentials and PII data for travel rule compliance when withdrawing from exchanges like Binance.
+        /// </remarks>
+        /// <returns>The public key response</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<Trakx.Common.ApiClient.Response<ExchangeCredentialsPublicKeyResponse>> GetExchangeAccountsCredentialsPublicKeyAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "exchange_accounts/credentials_public_key"
+                    urlBuilder_.Append("exchange_accounts/credentials_public_key");
+
+                    await PrepareRequestAsync(client_, request_, urlBuilder_, cancellationToken).ConfigureAwait(false);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    await PrepareRequestAsync(client_, request_, url_, cancellationToken).ConfigureAwait(false);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        await ProcessResponseAsync(client_, response_, cancellationToken).ConfigureAwait(false);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ExchangeCredentialsPublicKeyResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return new Trakx.Common.ApiClient.Response<ExchangeCredentialsPublicKeyResponse>(status_, headers_, objectResponse_.Object);
+                        }
+                        else
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ErrorSchema>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ErrorSchema>("Error Response", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)

--- a/src/Trakx.Fireblocks.ApiClient/FireblocksApiInterfacesAndModels.cs
+++ b/src/Trakx.Fireblocks.ApiClient/FireblocksApiInterfacesAndModels.cs
@@ -520,6 +520,17 @@ namespace Trakx.Fireblocks.ApiClient
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<Trakx.Common.ApiClient.Response<ExchangeAsset>> GetExchangeAccountAssetAsync(string exchangeAccountId, string assetId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get exchange credentials public key
+        /// </summary>
+        /// <remarks>
+        /// Returns the public key used to encrypt exchange account credentials and PII data for travel rule compliance when withdrawing from exchanges like Binance.
+        /// </remarks>
+        /// <returns>The public key response</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<Trakx.Common.ApiClient.Response<ExchangeCredentialsPublicKeyResponse>> GetExchangeAccountsCredentialsPublicKeyAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -3703,6 +3714,27 @@ namespace Trakx.Fireblocks.ApiClient
 
         [Newtonsoft.Json.JsonProperty("nextUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string NextUrl { get; init; }
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial record ExchangeCredentialsPublicKeyResponse
+    {
+
+        /// <summary>
+        /// The RSA public key in PEM format used to encrypt exchange credentials/PII data
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("publicKey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string PublicKey { get; init; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 

--- a/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
+++ b/src/Trakx.Fireblocks.ApiClient/openApi3.yaml
@@ -1671,6 +1671,27 @@ paths:
         default:
           $ref: '#/components/responses/Error'
       operationId: getExchangeAccountAsset
+  /exchange_accounts/credentials_public_key:
+    get:
+      summary: Get exchange credentials public key
+      description: >-
+        Returns the public key used to encrypt exchange account credentials and PII data
+        for travel rule compliance when withdrawing from exchanges like Binance.
+      tags:
+        - Exchange accounts
+      responses:
+        '200':
+          description: The public key response
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExchangeCredentialsPublicKeyResponse'
+        default:
+          $ref: '#/components/responses/Error'
+      operationId: getExchangeAccountsCredentialsPublicKey
   /fiat_accounts:
     get:
       summary: List fiat accounts
@@ -8972,6 +8993,12 @@ components:
           type: string
         nextUrl:
           type: string
+    ExchangeCredentialsPublicKeyResponse:
+      type: object
+      properties:
+        publicKey:
+          type: string
+          description: The RSA public key in PEM format used to encrypt exchange credentials/PII data
     TradingAccountType:
       type: string
       enum:

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Integration/ExchangeAccountsClientTests.cs
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Integration/ExchangeAccountsClientTests.cs
@@ -19,4 +19,13 @@ public class ExchangeAccountsClientTests : FireblocksClientTestsBase
         var response = await _exchangeAccountsClient.GetPagedExchangeAccountsAsync(5);
         response.Content.Exchanges.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task GetExchangeAccountsCredentialsPublicKeyAsync_should_return_public_key()
+    {
+        var response = await _exchangeAccountsClient.GetExchangeAccountsCredentialsPublicKeyAsync();
+        response.Content.Should().NotBeNull();
+        response.Content.PublicKey.Should().NotBeNullOrEmpty();
+        response.Content.PublicKey.Should().StartWith("-----BEGIN PUBLIC KEY-----");
+    }
 }

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Trakx.Fireblocks.ApiClient.Tests.csproj
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Trakx.Fireblocks.ApiClient.Tests.csproj
@@ -38,6 +38,9 @@
     <None Update="Unit\Serialisation\sampleGetAllExchangesResponse.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Unit\Serialisation\sampleCredentialsPublicKeyResponse.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/ExchangeCredentialsPublicKeyResponseSerialisationTests.cs
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/ExchangeCredentialsPublicKeyResponseSerialisationTests.cs
@@ -1,0 +1,31 @@
+namespace Trakx.Fireblocks.ApiClient.Tests.Unit.Serialisation;
+
+public class ExchangeCredentialsPublicKeyResponseSerialisationTests
+{
+    [Fact]
+    public void Should_Deserialise_credentials_public_key_response()
+    {
+        var responseContent = File.ReadAllText("Unit/Serialisation/sampleCredentialsPublicKeyResponse.json");
+        var response = Newtonsoft.Json.JsonConvert.DeserializeObject<ExchangeCredentialsPublicKeyResponse>(responseContent);
+
+        response.Should().NotBeNull();
+        response!.PublicKey.Should().NotBeNullOrEmpty();
+        response.PublicKey.Should().StartWith("-----BEGIN PUBLIC KEY-----");
+        response.PublicKey.Should().EndWith("-----END PUBLIC KEY-----\n");
+    }
+
+    [Fact]
+    public void Should_Serialise_credentials_public_key_response_back_and_forth()
+    {
+        var original = new ExchangeCredentialsPublicKeyResponse
+        {
+            PublicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\n-----END PUBLIC KEY-----"
+        };
+
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(original);
+        var deserialised = Newtonsoft.Json.JsonConvert.DeserializeObject<ExchangeCredentialsPublicKeyResponse>(json);
+
+        deserialised.Should().NotBeNull();
+        deserialised!.PublicKey.Should().Be(original.PublicKey);
+    }
+}

--- a/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleCredentialsPublicKeyResponse.json
+++ b/tests/Trakx.Fireblocks.ApiClient.Tests/Unit/Serialisation/sampleCredentialsPublicKeyResponse.json
@@ -1,0 +1,4 @@
+{
+  "publicKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAgdddajdlaskjdlksajdklsajlKaxObwTgIQhw\nbqsafdksjhfivubkesjdhgisuhigushiuV7erdP\ncrNQreedsdflkjdslkjafgleunrdgoalidla\nH9be3dPmZJRHWjuZg6iUVycCAwEAAQ==\n-----END PUBLIC KEY-----\n",
+  "tenantId": "aaaaaaaa-bbbb-cccc-1234-1234aaaabbbb"
+}


### PR DESCRIPTION
Added `GetExchangeAccountsCredentialsPublicKeyAsync` method to fetch the RSA public key, enabling secure exchange credentials encryption.